### PR TITLE
Fix Eshell not closing error

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -1170,7 +1170,7 @@ or the name of the currently selected file.")
     (kill-buffer tmp)
     (add-hook 'eshell-exit-hook
               '(lambda () (unless (one-window-p) (delete-window))
-                 (select-window 'ranger-window)) nil t)))
+                 (select-window ranger-window)) nil t)))
 
 
 ;;; delayed function creation


### PR DESCRIPTION
Fix for issue #174  

#'select-window needs a window-object as an argument, but gets a symbol. Removing the quote fixes this problem since a window-object is stored in the ranger-window variable. 
