### PR TITLE
wdired-finish-edit: Handle missing directory header when entering wdired from ranger

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -968,6 +968,22 @@ to not replace existing value."
                   (ranger-mode)))
               '((name . ranger-wdired-abort)))
 
+  (advice-add 'wdired-finish-edit :before
+              (lambda (&rest _)
+                (when (and ranger-was-ranger
+                           (= (line-number-at-pos (point-min)) 1)
+                           (save-excursion
+                             (goto-char (point-min))
+                             (dired-move-to-filename)))
+                  ;; Insert an empty line at the top so wdired-finish-edit's
+                  ;; reverse loop doesn't skip changes made to line 1.
+                  (save-excursion
+                    (goto-char (point-min))
+                    (let ((inhibit-read-only t))
+                      (insert "
+")))))
+              '((name . ranger-fix-wdired-finish-edit-bobp)))
+
   (advice-add 'wdired-finish-edit :after
               (lambda (&rest _args)
                 (when ranger-was-ranger


### PR DESCRIPTION
wdired's rename loop in `wdired-finish-edit` iterates backwards using `(while (not (bobp)) ... (forward-line -1))`. In standard dired buffers, line 1 is a directory header (e.g., "/path/to/dir:"), so the loop safely terminates at `point-min` without skipping any file entries.

Ranger omits the directory header, placing the first file directly at `point-min` (position 1). When the loop reaches line 2 and calls `(forward-line -1)`, point moves to position 1 where `(bobp)` returns t, causing the loop to exit before processing the first file. This results in renames on the first file being silently discarded with "(No changes to be performed)".

Fix by advising `wdired-finish-edit` with a `:before` function that inserts a temporary newline at `point-min` when all of the following are true:
- Buffer was previously in ranger-mode (`ranger-was-ranger`)
- `point-min` is on line 1 (no existing header)
- Line 1 contains a valid filename (`dired-move-to-filename`)

This shifts the first file entry off `point-min`, allowing the loop to process it before `(bobp)` terminates iteration.