### PR TITLE
ls-lisp:fix: Restore ls-lisp-use-insert-directory-program on ranger exit

### DIFF
--- a/ranger.el
+++ b/ranger.el
@@ -349,6 +349,7 @@ toggles (z). Requires the hydra package to be installed."
 (defvar ranger-pre-hl-mode nil)
 (defvar ranger-pre-arev-mode nil)
 (defvar ranger-pre-dired-listing nil)
+(defvar ranger-pre-ls-lisp-use-insert-directory-program nil)
 
 (defvar ranger-preview-window nil)
 (defvar ranger-preview-buffers ()
@@ -2608,6 +2609,11 @@ fraction of the total frame size"
         ;; (setq ranger-mode nil)
         ;; hide details line at top
         (funcall 'remove-from-invisibility-spec 'dired-hide-details-information)
+        ;; Restore ls-lisp state
+        (if (eq ranger-pre-ls-lisp-use-insert-directory-program :unbound)
+            (makunbound 'ls-lisp-use-insert-directory-program)
+          (setq ls-lisp-use-insert-directory-program
+                ranger-pre-ls-lisp-use-insert-directory-program))
         ;; sort dired with previous listing options
         (dired-sort-other dired-listing-switches)
         ))))
@@ -3007,6 +3013,11 @@ properly provides the modeline in dired mode. "
 (defun ranger-disable ()
   "Interactively disable ranger-mode."
   (interactive)
+  ;; Restore global ls-lisp state so future dired buffers use system ls
+  (if (eq ranger-pre-ls-lisp-use-insert-directory-program :unbound)
+      (makunbound 'ls-lisp-use-insert-directory-program)
+    (setq ls-lisp-use-insert-directory-program
+          ranger-pre-ls-lisp-use-insert-directory-program))
   ;; don't kill ranger buffer if open somewhere else
   (if (> (length (get-buffer-window-list)) 1)
       (progn
@@ -3036,14 +3047,10 @@ properly provides the modeline in dired mode. "
   (setq ls-lisp-gid-s-fmt "%-8s")
   ;; don't mix dotfiles with directories
   (setq ls-lisp-UCA-like-collation nil)
-  ;; (setq ls-lisp-use-insert-directory-program nil)
 
   (setq ls-lisp-format-time-list
         '("%Y-%m-%d %H:%M"
           "%Y-%m-%d %H:%M"))
-
-  (setq ls-lisp-use-insert-directory-program nil)
-  (require 'ls-lisp)
 
   (unless (derived-mode-p 'dired-mode)
     (error "Run it from dired buffer"))
@@ -3066,7 +3073,14 @@ properly provides the modeline in dired mode. "
     (setq ranger-pre-hl-mode hl-line-mode)
     (setq ranger-pre-arev-mode auto-revert-mode)
     (setq ranger-pre-dired-listing dired-listing-switches)
+    (setq ranger-pre-ls-lisp-use-insert-directory-program
+          (if (boundp 'ls-lisp-use-insert-directory-program)
+              ls-lisp-use-insert-directory-program
+            :unbound))
     (setq ranger-pre-saved t))
+
+  (setq ls-lisp-use-insert-directory-program nil)
+  (require 'ls-lisp)
 
   ;; save window-config for frame unless already
   ;; specified from running `ranger'


### PR DESCRIPTION
ranger-setup sets ls-lisp-use-insert-directory-program to nil but never restores it, causing all dired buffers to use ls-lisp's compact listing format after ranger exits.

Save the prior value (including the unbound/void case) on ranger entry and restore it in both ranger-disable (for future dired buffers) and ranger-revert-appearance before dired-sort-other (for already-open dired buffers).

Fixes https://github.com/punassuming/ranger.el/issues/258

## Testing

Opening dired before and after ranger activation/deactivation shows the same ls behavior. `ls-lisp-use-insert-directory-program` during ranger remains `nil` as required by ranger. Evaluating `ls-lisp-use-insert-directory-program` in any subsequent dired buffers will correctly evaluate to void variable, the default.